### PR TITLE
Rename trackedEntity to trackedEntityType

### DIFF
--- a/lib/populator.js
+++ b/lib/populator.js
@@ -109,7 +109,7 @@ Populator.prototype._getDataElementType = function (dataElementID, next) {
 Populator.prototype._addTrackedEntity = function (knownKeys, trackedEntityAttributes, next) {
   this.emit('addTrackedEntity');
   var payload = {
-    trackedEntity: this._options.trackedEntityID,
+    trackedEntityType: this._options.trackedEntityID,
     orgUnit: knownKeys.orgUnit,
     attributes: []
   };
@@ -184,7 +184,7 @@ Populator.prototype._getTrackedEntityInstanceID = function (knownKeys, trackedEn
 Populator.prototype._updateTrackedEntityInstance = function (knownKeys, trackedEntityAttributes, trackedEntityInstanceID, next) {
   this.emit('updateTrackedEntityInstance');
   var payload = {
-    trackedEntity: this._options.trackedEntityID,
+    trackedEntityType: this._options.trackedEntityID,
     orgUnit: knownKeys.orgUnit,
     attributes: []
   };

--- a/test/integration.js
+++ b/test/integration.js
@@ -80,7 +80,7 @@ describe('Tracker populator', function () {
       var addTrackedEntityRequest = Sinon.match({
         url: URL.resolve(options.url, 'api/trackedEntityInstances'),
         json: Sinon.match({
-          trackedEntity: 'trackedEntityID',
+          trackedEntityType: 'trackedEntityID',
           orgUnit: 'expectedOrgUnit',
           attributes: Sinon.match([
             Sinon.match({

--- a/test/unit.js
+++ b/test/unit.js
@@ -61,7 +61,7 @@ describe('Populator', function () {
   describe('#addTrackedEntity', function () {
 
     var requestObjectBody = {
-      trackedEntityType: OPTIONS.trackedEntityInstanceID,
+      trackedEntityType: OPTIONS.trackedEntityID,
       orgUnit: KNOWN_KEYS.orgUnit,
       attributes: ATTRIBUTES
     };
@@ -853,7 +853,7 @@ describe('Populator', function () {
     var trackedEntityInstanceID = 'some tracked entity instance id';
 
     var requestObjectBody = {
-      trackedEntityType: OPTIONS.trackedEntityInstanceID,
+      trackedEntityType: OPTIONS.trackedEntityID,
       orgUnit: KNOWN_KEYS.orgUnit,
       attributes: ATTRIBUTES
     };
@@ -1191,7 +1191,7 @@ describe('Populator with defined dhis api version', function () {
   describe('#addTrackedEntity', function () {
 
     var requestObjectBody = {
-      trackedEntityType: OPTIONS.trackedEntityInstanceID,
+      trackedEntityType: OPTIONS.trackedEntityID,
       orgUnit: KNOWN_KEYS.orgUnit,
       attributes: ATTRIBUTES
     };

--- a/test/unit.js
+++ b/test/unit.js
@@ -61,7 +61,7 @@ describe('Populator', function () {
   describe('#addTrackedEntity', function () {
 
     var requestObjectBody = {
-      trackedEntity: OPTIONS.trackedEntityInstanceID,
+      trackedEntityType: OPTIONS.trackedEntityInstanceID,
       orgUnit: KNOWN_KEYS.orgUnit,
       attributes: ATTRIBUTES
     };
@@ -81,7 +81,7 @@ describe('Populator', function () {
     var addTrackedEntityRequest = Sinon.match({
       url: URL.resolve(OPTIONS.url, 'api/trackedEntityInstances'),
       json: Sinon.match({
-        trackedEntity: OPTIONS.trackedEntityID,
+        trackedEntityType: OPTIONS.trackedEntityID,
         orgUnit: KNOWN_KEYS.orgUnit,
         attributes: Sinon.match(Object.keys(ATTRIBUTES).map(function (key) {
           return Sinon.match({
@@ -853,7 +853,7 @@ describe('Populator', function () {
     var trackedEntityInstanceID = 'some tracked entity instance id';
 
     var requestObjectBody = {
-      trackedEntity: OPTIONS.trackedEntityInstanceID,
+      trackedEntityType: OPTIONS.trackedEntityInstanceID,
       orgUnit: KNOWN_KEYS.orgUnit,
       attributes: ATTRIBUTES
     };
@@ -873,7 +873,7 @@ describe('Populator', function () {
     var updateTrackedEntityInstanceRequest = Sinon.match({
       url: URL.resolve(OPTIONS.url, 'api/trackedEntityInstances/' + trackedEntityInstanceID),
       json: Sinon.match({
-        trackedEntity: OPTIONS.trackedEntityID,
+        trackedEntityType: OPTIONS.trackedEntityID,
         orgUnit: KNOWN_KEYS.orgUnit,
         attributes: Sinon.match(Object.keys(ATTRIBUTES).map(function (key) {
           return Sinon.match({
@@ -1191,7 +1191,7 @@ describe('Populator with defined dhis api version', function () {
   describe('#addTrackedEntity', function () {
 
     var requestObjectBody = {
-      trackedEntity: OPTIONS.trackedEntityInstanceID,
+      trackedEntityType: OPTIONS.trackedEntityInstanceID,
       orgUnit: KNOWN_KEYS.orgUnit,
       attributes: ATTRIBUTES
     };
@@ -1211,7 +1211,7 @@ describe('Populator with defined dhis api version', function () {
     var addTrackedEntityRequest = Sinon.match({
       url: URL.resolve(OPTIONS.url, 'api/28/trackedEntityInstances'),
       json: Sinon.match({
-        trackedEntity: OPTIONS.trackedEntityID,
+        trackedEntityType: OPTIONS.trackedEntityID,
         orgUnit: KNOWN_KEYS.orgUnit,
         attributes: Sinon.match(Object.keys(ATTRIBUTES).map(function (key) {
           return Sinon.match({


### PR DESCRIPTION
The object was renamed in DHIS2 version 29 which caused the populator to
stop working. Renaming this field in requests made by the populator
resolves the issue.